### PR TITLE
feature/#18 アカウント作成時とログイン時に求められる値がシリアル番号とパスワードのみになるように変更し、idをオートインクリメ…

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -123,7 +123,7 @@ class Application extends BaseApplication
 
         $authenticationService->loadIdentifier('Authentication.Password', [
             'fields' => [
-                'username' => 'email',
+                'username' => 'serial_number',
                 'password' => 'password',
             ]
         ]);
@@ -131,7 +131,7 @@ class Application extends BaseApplication
         $authenticationService->loadAuthenticator('Authentication.Session');
         $authenticationService->loadAuthenticator('Authentication.Form', [
             'fields' => [
-                'username' => 'email',
+                'username' => 'serial_number',
                 'password' => 'password',
             ],
             'loginUrl' => '/li-learn-timer/users/login',

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -30,18 +30,13 @@ class UsersController extends AppController
         $user = $this->Users->newEmptyEntity();
         if ($this->request->is('post')) {
             $this->loadModel('Units');
-            $data['id'] = bin2hex(random_bytes(5)) . uniqid();
-            $data += $this->request->getData();
+            $data = $this->request->getData();
             $serialNumber = $this->Units
                 ->find('all')
                 ->where(['serial_number' => $data['serial_number'], 'status' => '未登録']);
 
-            if ($serialNumber->count() === 0) {
-                $this->Flash->error(__('入力されたシリアル番号は既に登録されているか、存在しません。'));
-                $this->set(compact('user', 'title'));
-                return;
-            } else if ($serialNumber->count() > 1) {
-                $this->Flash->error(__('入力されたシリアル番号はデータベースに複数存在します。'));
+            if (!$serialNumber->count()) {
+                $this->Flash->error(__('入力されたシリアル番号は存在しないか、既に登録されています。'));
                 $this->set(compact('user', 'title'));
                 return;
             }

--- a/src/Model/Entity/User.php
+++ b/src/Model/Entity/User.php
@@ -32,7 +32,8 @@ class User extends Entity
      * @var array
      */
     protected $_accessible = [
-        '*' => true
+        '*' => true,
+        'id' => false
     ];
 
     protected function _setPassword($password)

--- a/src/Model/Table/UsersTable.php
+++ b/src/Model/Table/UsersTable.php
@@ -49,8 +49,6 @@ class UsersTable extends Table
 
         $this->hasMany('Tasks')
             ->setForeignKey('user_id');
-        $this->belongsTo('Units')
-            ->setForeignKey('serial_number');
     }
 
     /**
@@ -63,31 +61,19 @@ class UsersTable extends Table
     {
         $validator
             ->scalar('id')
-            ->maxLength('id', 23)
             ->allowEmptyString('id', null, 'create');
 
         $validator
-            ->scalar('username')
-            ->maxLength('username', 255, 'ユーザー名は255文字以内で入力してください。')
-            ->requirePresence('username', 'create', '値が不正です。')
-            ->notEmptyString('username', '入力必須項目です。');
-
-        $validator
-            ->email('email', false, 'メールアドレスを正しい形式で入力してください。')
-            ->requirePresence('email', 'create', '値が不正です。')
-            ->notEmptyString('email', '入力必須項目です。');
+            ->scalar('serial_number')
+            ->lengthBetween('serial_number', [12, 12], '12文字で入力してください')
+            ->requirePresence('serial_number', 'create', '値が不正です。')
+            ->notEmptyString('serial_number', '入力必須項目です。');
 
         $validator
             ->scalar('password')
             ->lengthBetween('password', [8, 100], 'パスワードは8文字以上100文字以内で入力してください。')
             ->requirePresence('password', 'create', '値が不正です。')
             ->notEmptyString('password', '入力必須項目です。');
-
-        $validator
-            ->scalar('serial_number')
-            ->lengthBetween('serial_number', [8, 8])
-            ->requirePresence('serial_number', 'create', '値が不正です。')
-            ->notEmptyString('serial_number', '入力必須項目です。');
 
         return $validator;
     }
@@ -101,8 +87,7 @@ class UsersTable extends Table
      */
     public function buildRules(RulesChecker $rules): RulesChecker
     {
-        $rules->add($rules->isUnique(['username']), ['errorField' => 'username']);
-        $rules->add($rules->isUnique(['email']), ['errorField' => 'email']);
+        $rules->add($rules->isUnique(['serial_number']), ['errorField' => 'serial_number']);
 
         return $rules;
     }

--- a/templates/Users/add.php
+++ b/templates/Users/add.php
@@ -10,10 +10,8 @@ $this->assign('title', $title);
     <fieldset>
         <legend><?= __('Add User') ?></legend>
         <?php
-            echo $this->Form->control('username');
-            echo $this->Form->control('email');
-            echo $this->Form->control('password');
-            echo $this->Form->control('serial_number');
+            echo $this->Form->control('serial_number', ['required' => true, 'label' => 'シリアル番号']);
+            echo $this->Form->control('password', ['required' => true, 'label' => 'パスワード']);
         ?>
     </fieldset>
     <?= $this->Form->button(__('Submit')) ?>

--- a/templates/Users/login.php
+++ b/templates/Users/login.php
@@ -4,8 +4,8 @@
     <?= $this->Form->create() ?>
     <fieldset>
       <legend><?= __('Login') ?></legend>
-      <?= $this->Form->control('email', ['required' => true]) ?>
-      <?= $this->Form->control('password', ['required' => true]) ?>
+      <?= $this->Form->control('serial_number', ['required' => true, 'label' => 'シリアル番号']) ?>
+      <?= $this->Form->control('password', ['required' => true, 'label' => 'パスワード']) ?>
     </fieldset>
     <?= $this->Form->submit(__('Login')); ?>
     <?= $this->Form->end() ?>


### PR DESCRIPTION
This resolve #18 

### やったこと

1. フォームをの内容を変更
2. DB構成を変更

### 備考
シリアル番号がプライマリーキーだと、CakePHPの仕様でアカウント作成時にシリアル番号の入力フォームが消失し(hiddenになる)、バリデーションなどのCakePHPの恩恵が受けられなくなるため、idがプライマリーキーかつオートインクリメントになった。